### PR TITLE
Removing golden zip

### DIFF
--- a/data/golden/feeFiFoFum.pbz2
+++ b/data/golden/feeFiFoFum.pbz2
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a4fff583d63c86b48e04f3c99f8b37e54cfe0d90f1041dbc712e220623bd69d7
-size 56326665


### PR DESCRIPTION
Git is mad at us for using too much bandwidth and we can not pull the full repo anymore.